### PR TITLE
FlatConvectorModel plays nice with optional properties

### DIFF
--- a/@worldsibu/convector-core-model/src/convector-model.ts
+++ b/@worldsibu/convector-core-model/src/convector-model.ts
@@ -12,9 +12,17 @@ import {
   getValidatedProperties
 } from '../src/validate.decorator';
 
-export type FlatConvectorModel<T> = {
-  [L in Exclude<keyof T, keyof ConvectorModel<any>>]: T[L]
-};
+export type RequiredKeys<T> = { [K in keyof T]-?:
+  string extends K ? never : number extends K ? never : {} extends Pick<T, K> ? never : K
+} extends { [_ in keyof T]-?: infer U } ? U extends keyof T ? U : never : never;
+
+export type OptionalKeys<T> = { [K in keyof T]-?:
+  string extends K ? never : number extends K ? never : {} extends Pick<T, K> ? K : never
+} extends { [_ in keyof T]-?: infer U } ? U extends keyof T ? U : never : never;
+
+export declare type FlatConvectorModel<T> =
+  {[L in Exclude<OptionalKeys<T>, keyof ConvectorModel<any>>]?: T[L]} &
+  {[L in Exclude<RequiredKeys<T>, keyof ConvectorModel<any>>]: T[L]};
 
 export interface History<T> {
   value: T;

--- a/@worldsibu/convector-core-model/tests/convector-model.spec.ts
+++ b/@worldsibu/convector-core-model/tests/convector-model.spec.ts
@@ -7,7 +7,7 @@ import 'mocha';
 import 'reflect-metadata';
 
 import { Validate } from '../src/validate.decorator';
-import { ConvectorModel } from '../src/convector-model';
+import { ConvectorModel, FlatConvectorModel } from '../src/convector-model';
 
 class TestStorage extends BaseStorage {
   private storage = new Map();
@@ -52,6 +52,17 @@ class TestModel extends ConvectorModel<TestModel> {
 
   @Validate(yup.string())
   public name: string;
+
+  @Validate(yup.number())
+  public optionalProperty?: number;
+}
+
+class TestFlatModel extends ConvectorModel<TestFlatModel> {
+  public type = 'io.worldsibu.test2';
+
+  @Validate(TestModel)
+  public child: FlatConvectorModel<TestModel>;
+
 }
 
 describe('Convector Model', () => {
@@ -185,4 +196,22 @@ describe('Convector Model', () => {
     expect(history[1].value.name).to.eq('2');
     expect(history[2].value.name).to.eq('3');
   });
+});
+
+describe('FlatConvectorModel', ()=>{
+  it('Should ignore optional property', ()=>{
+    var item = new TestModel();
+    var parent = new TestFlatModel();
+    parent.child = item;
+    expect(parent.child.optionalProperty).to.undefined;
+  });
+
+  it('Should set optional property', ()=>{
+    var item = new TestModel();
+    var parent = new TestFlatModel();
+    parent.child = item;
+    item.optionalProperty = 12345;
+    expect(parent.child.optionalProperty).to.equal(12345);
+  });
+
 });


### PR DESCRIPTION
## Proposed changes

When using `FlatConvectorModel<T>` it should work properly when T has optional properties.

[See this issue](https://github.com/hyperledger-labs/convector/issues/56)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


