### PR TITLE
fix: getOne error when not found by id

### DIFF
--- a/@worldsibu/convector-core-model/src/convector-model.ts
+++ b/@worldsibu/convector-core-model/src/convector-model.ts
@@ -65,7 +65,7 @@ export abstract class ConvectorModel<T extends ConvectorModel<any>> {
 
     const model = new type(content);
 
-    if (content.type !== model.type) {
+    if ((content && model) && content.type !== model.type) {
       throw new Error(`Possible ID collision, element ${id} of type ${content.type} is not ${model.type}`);
     }
 

--- a/@worldsibu/convector-core-model/tests/convector-model.spec.ts
+++ b/@worldsibu/convector-core-model/tests/convector-model.spec.ts
@@ -190,6 +190,11 @@ describe('Convector Model', () => {
     expect(results.length).to.eq(3);
   });
 
+  it('should return an empty model when not found in DB', async () => {
+    const result = await TestModel.getOne('invalid-id');
+    expect(result.id).to.undefined;
+  });
+
   it('should extract the model schema', () => {
     const schema = TestModel.schema();
     const flatModel = schema.validateSync({


### PR DESCRIPTION
Signed-off-by: Richard <rookard@gmail.com>

## Proposed changes

When calling getOne with an id that doesnt exist, you get an error 

`Cannot read property 'type' of null`

## Types of changes

What types of changes does your code introduce to Convector?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I have made the assumption that getOne called with an id that does not exist should return an empty model of the relevant type - this was the previous behaviour.
