### PR TITLE
fix: patch theledger library for fabric-chaincode-utils

### DIFF
--- a/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
@@ -1,9 +1,14 @@
 /** @module @worldsibu/convector-adapter-mock */
 
 import * as uuid from 'uuid/v1';
+import { ControllerAdapter } from '@worldsibu/convector-core-adapter';
 import { Chaincode, IConfig } from '@worldsibu/convector-core-chaincode';
 import { ChaincodeMockStub, Transform } from '@theledger/fabric-mock-stub';
-import { ControllerAdapter } from '@worldsibu/convector-core-adapter';
+
+// Remove when this gets merged
+// https://github.com/wearetheledger/fabric-node-chaincode-utils/pull/23
+import { Transform as _Transform } from '@theledger/fabric-chaincode-utils';
+_Transform.isObject = data => data !== null && typeof data === 'object';
 
 export class MockControllerAdapter implements ControllerAdapter {
   public stub = new ChaincodeMockStub('Participant', new Chaincode());

--- a/@worldsibu/convector-storage-stub/src/stub-storage.ts
+++ b/@worldsibu/convector-storage-stub/src/stub-storage.ts
@@ -1,9 +1,13 @@
 /** @module @worldsibu/convector-storage-stub */
 
 import { ChaincodeStub } from 'fabric-shim';
-import { InvalidIdError } from '@worldsibu/convector-core-errors';
-import { StubHelper } from '@theledger/fabric-chaincode-utils';
 import { BaseStorage } from '@worldsibu/convector-core-storage';
+import { InvalidIdError } from '@worldsibu/convector-core-errors';
+import { StubHelper, Transform } from '@theledger/fabric-chaincode-utils';
+
+// Remove when this gets merged
+// https://github.com/wearetheledger/fabric-node-chaincode-utils/pull/23
+Transform.isObject = data => data !== null && typeof data === 'object';
 
 export class StubStorage extends BaseStorage {
   private stubHelper: StubHelper;


### PR DESCRIPTION
## Proposed changes

fabric-chaincode-utils has an error with a PR already in place https://github.com/wearetheledger/fabric-node-chaincode-utils/pull/23
But this is holding on the release, so we're patching it

## Types of changes

What types of changes does your code introduce to Convector?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)