### PR TITLE
feat: transient and private data features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 #   # -
 install:
   - npm install
-  - npm run lerna:install
   - npm run lerna:lint
   - npm run lerna:test
 #   # - npm run publish:ci

--- a/@worldsibu/convector-adapter-browser/package.json
+++ b/@worldsibu/convector-adapter-browser/package.json
@@ -28,9 +28,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core-adapter": "1.2.0",
-    "@worldsibu/convector-core-controller": "1.2.0",
-    "@worldsibu/convector-core-errors": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-adapter-browser/src/browser.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-browser/src/browser.controller-adapter.ts
@@ -1,7 +1,6 @@
 /** @module @worldsibu/convector-adapter-browser */
 
-import { ControllerAdapter } from '@worldsibu/convector-core-adapter';
-import { ConvectorController, getInvokables } from '@worldsibu/convector-core-controller';
+import { ControllerAdapter, ConvectorController, getInvokables } from '@worldsibu/convector-core';
 
 export class BrowserControllerAdapter implements ControllerAdapter {
   private user: string;
@@ -23,7 +22,7 @@ export class BrowserControllerAdapter implements ControllerAdapter {
   public async invoke(
     controller: string,
     name: string,
-    adminOrUser?: string|true,
+    config: any = {},
     ...args: any[]
   ) {
     const ctrl = this.controllers.get(controller);
@@ -31,7 +30,7 @@ export class BrowserControllerAdapter implements ControllerAdapter {
       { [controller]: ctrl },
       {},
       args.map(a => typeof a === 'string' ? a : JSON.stringify(a)),
-      { sender: { value: adminOrUser || this.user } }
+      { sender: { value: config.user || this.user } }
     );
   }
 }

--- a/@worldsibu/convector-adapter-browser/tests/browser.controller-adapter.spec.ts
+++ b/@worldsibu/convector-adapter-browser/tests/browser.controller-adapter.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import 'mocha';
 import 'reflect-metadata';
 
-import { ConvectorController, Controller, Invokable, Param } from '@worldsibu/convector-core-controller';
+import { ConvectorController, Controller, Invokable } from '@worldsibu/convector-core';
 
 import { BrowserControllerAdapter } from '../src/browser.controller-adapter';
 

--- a/@worldsibu/convector-adapter-fabric/package.json
+++ b/@worldsibu/convector-adapter-fabric/package.json
@@ -32,8 +32,7 @@
   },
   "dependencies": {
     "@worldsibu/convector-common-fabric-helper": "1.2.0",
-    "@worldsibu/convector-core-adapter": "1.2.0",
-    "@worldsibu/convector-core-errors": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-adapter-fabric/src/fabric.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric/src/fabric.controller-adapter.ts
@@ -1,6 +1,6 @@
 /** @module @worldsibu/convector-adapter-fabric */
 
-import { ControllerAdapter } from '@worldsibu/convector-core-adapter';
+import { ControllerAdapter } from '@worldsibu/convector-core';
 import { ClientHelper, ClientConfig, TxResult } from '@worldsibu/convector-common-fabric-helper';
 
 export { TxResult };
@@ -14,8 +14,13 @@ export class FabricControllerAdapter extends ClientHelper implements ControllerA
     super(config);
   }
 
-  public async invoke(controller: string, name: string, adminOrUser?: string|true, ...args: any[]): Promise<any> {
-    const txResult = await super.invoke(`${controller}_${name}`, this.config.chaincode, adminOrUser, ...args);
+  public async invoke(controller: string, name: string, config?: any, ...args: any[]): Promise<any> {
+    const txResult = await super.invoke(`${controller}_${name}`, this.config.chaincode, config, ...args);
+    return txResult.result;
+  }
+
+  public async query(controller: string, name: string, config?: any, ...args: any[]): Promise<any> {
+    const txResult = await super.query(`${controller}_${name}`, this.config.chaincode, config, ...args);
     return txResult.result;
   }
 }

--- a/@worldsibu/convector-adapter-mock/package.json
+++ b/@worldsibu/convector-adapter-mock/package.json
@@ -28,9 +28,8 @@
   },
   "dependencies": {
     "@theledger/fabric-mock-stub": "^4.0.0",
-    "@worldsibu/convector-core-adapter": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "@worldsibu/convector-core-chaincode": "1.2.0",
-    "@worldsibu/convector-core-errors": "1.2.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
@@ -1,7 +1,7 @@
 /** @module @worldsibu/convector-adapter-mock */
 
 import * as uuid from 'uuid/v1';
-import { ControllerAdapter } from '@worldsibu/convector-core-adapter';
+import { ControllerAdapter } from '@worldsibu/convector-core';
 import { Chaincode, IConfig } from '@worldsibu/convector-core-chaincode';
 import { ChaincodeMockStub, Transform } from '@theledger/fabric-mock-stub';
 
@@ -23,11 +23,19 @@ export class MockControllerAdapter implements ControllerAdapter {
     return Transform.bufferToObject(response) as any;
   }
 
-  public async invoke(controller: string, name: string, adminOrUser?: string|true, ...args: any[]) {
+  public async invoke(controller: string, name: string, config: any = {}, ...args: any[]) {
+    this.stub['usercert'] = config.user ? config.user : this.stub['usercert'];
+
+    const transientMap = Object.keys(config.transient || {}).reduce((map, k) => {
+      const v = config.transient[k];
+      map.set(k, Buffer.from(typeof v === 'string' ? v : JSON.stringify(v)));
+      return map;
+    }, new Map<string, Buffer>());
+
     const response = await this.stub.mockInvoke(uuid(), [
       `${controller}_${name}`,
       ...args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg.toString())
-    ]);
+    ], transientMap);
 
     return Transform.bufferToObject(response.payload);
   }

--- a/@worldsibu/convector-core-adapter/package.json
+++ b/@worldsibu/convector-core-adapter/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "commander": "^2.15.1",
     "http-server": "^0.11.1",
+    "mocha": "^5.0.3",
     "npm-scripts-watcher": "^1.0.2",
     "rimraf": "^2.6.2",
     "ts-node": "^6.0.3",

--- a/@worldsibu/convector-core-adapter/src/controller-adapter.ts
+++ b/@worldsibu/convector-core-adapter/src/controller-adapter.ts
@@ -16,8 +16,18 @@ export interface ControllerAdapter {
    *
    * @param controller The controller namespace
    * @param name The function name
-   * @param adminOrUser It the call must be peformed with the admin user or with a custom one
+   * @param config Extra paramters to the custom adapter
    * @param args The arguments for the function
    */
-  invoke(controller: string, name: string, adminOrUser?: string|true, ...args: any[]): Promise<any>;
+  invoke(controller: string, name: string, config?: any, ...args: any[]): Promise<any>;
+
+  /**
+   * This is going to be called whenever a controller needs to query the chaincode
+   *
+   * @param controller The controller namespace
+   * @param name The function name
+   * @param config Extra paramters to the custom adapter
+   * @param args The arguments for the function
+   */
+  query?(controller: string, name: string, config?: any, ...args: any[]): Promise<any>;
 }

--- a/@worldsibu/convector-core-adapter/src/controller-client.ts
+++ b/@worldsibu/convector-core-adapter/src/controller-client.ts
@@ -2,31 +2,53 @@ import { ConvectorController, getInvokables } from '@worldsibu/convector-core-co
 
 import { ControllerAdapter } from './controller-adapter';
 
-export interface IConvectorControllerClient {
+export interface IConvectorControllerClient<T extends ConvectorController> {
+  config: any;
+  query: boolean;
   user: string|true;
+  ctrl: new (content?: any) => T;
+  adapter: ControllerAdapter;
 }
 
 export const controllerClientMethods = {
-  $withUser(this: IConvectorControllerClient, user: string|true) {
-    this.user = user;
-    return this;
+  $withUser<T extends ConvectorController>(this: IConvectorControllerClient<T>, user: string|true) {
+    const newClient = ClientFactory(this.ctrl, this.adapter);
+    newClient.user = user;
+    return newClient;
+  },
+  $query<T extends ConvectorController>(this: IConvectorControllerClient<T>) {
+    const newClient = ClientFactory(this.ctrl, this.adapter);
+    newClient.query = true;
+    return newClient;
+  },
+  $config<T extends ConvectorController>(this: IConvectorControllerClient<T>, config: any) {
+    const newClient = ClientFactory(this.ctrl, this.adapter);
+    newClient.config = config;
+    return newClient;
   }
 };
 
-export type ConvectorControllerClient<T> = typeof controllerClientMethods&T;
+export type ConvectorControllerClient<T extends ConvectorController> =
+  typeof controllerClientMethods&IConvectorControllerClient<T>&T;
 
 export function ClientFactory<T extends ConvectorController>(
   ctrl: new (content?: any) => T,
   adapter: ControllerAdapter
 ): ConvectorControllerClient<T> {
   const client: ConvectorControllerClient<T> = new ctrl() as any;
-  Object.assign(client, controllerClientMethods);
+  Object.assign(client, { ctrl, adapter, query: false }, controllerClientMethods);
 
   const { namespace, invokables } = getInvokables(ctrl);
 
   for (let fn in invokables) {
-    client[fn] = function ControllerClientWrapper(this: IConvectorControllerClient, ...args) {
-      return adapter.invoke(namespace, fn, this.user, ...args);
+    client[fn] = function ControllerClientWrapper(this: IConvectorControllerClient<T>, ...args) {
+      const config = { ...this.config, user: this.user };
+
+      if (this.query && adapter.query) {
+        return adapter.query(namespace, fn, config, ...args);
+      }
+
+      return adapter.invoke(namespace, fn, config, ...args);
     };
   }
 

--- a/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
+++ b/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
@@ -1,5 +1,6 @@
 // tslint:disable:no-unused-expression
 
+import * as yup from 'yup';
 import { expect } from 'chai';
 import 'mocha';
 import 'reflect-metadata';
@@ -27,7 +28,15 @@ class TestAdapter implements ControllerAdapter {
     this.ctrl = new ctrl();
   }
 
-  async invoke(controller, name, user, ...args) {
+  async invoke(controller, name, config, ...args) {
+    if (config.test) {
+      return 'from-adapter';
+    }
+
+    return this.ctrl[name]({}, args, {});
+  }
+
+  async query(controller, name, config, ...args) {
     return this.ctrl[name]({}, args, {});
   }
 }
@@ -38,5 +47,19 @@ describe('Controller Client', () => {
     const testCtrl = ClientFactory(TestController, adapter);
 
     expect(await testCtrl.test()).to.eq('works');
+  });
+
+  it('it should be able to query the controllers', async () => {
+    const adapter = new TestAdapter(TestController);
+    const testCtrl = ClientFactory(TestController, adapter);
+
+    expect(await testCtrl.$query().test()).to.eq('works');
+  });
+
+  it('it should pass the config to the adapter', async () => {
+    const adapter = new TestAdapter(TestController);
+    const testCtrl = ClientFactory(TestController, adapter);
+
+    expect(await testCtrl.$config({ test: true }).test()).to.eq('from-adapter');
   });
 });

--- a/@worldsibu/convector-core-chaincode/package.json
+++ b/@worldsibu/convector-core-chaincode/package.json
@@ -17,13 +17,12 @@
     "access": "public"
   },
   "scripts": {
-    "start": "pm2-runtime ./start.js",
-    "start:debug": "pm2-dev --node-args=\"--inspect=$DEBUG_PORT\" --watch=./packages ./start.js",
+    "start": "node ./start.js",
+    "start:debug": "nodemon --inspect=$DEBUG_PORT ./start.js",
     "------------ STANDARD TASKS ------------": "",
     "clean": "rimraf dist tests/dist",
     "clean:docs": "rimraf docs",
-    "build": "npm run clean && tsc && tsc -p ./tests/tsconfig.json && cp ./tests/ccc/package.json ./tests/dist/ccc/",
-    "copy:npmrc": "cp ../../npmrc dist/.npmrc",
+    "build": "npm run clean && tsc && tsc -p ./tests/tsconfig.json",
     "lint": "tslint --fix -c '../../tslint.json' -p './tsconfig.json'",
     "test": "mocha -r ts-node/register tests/**/*.spec.ts --reporter spec",
     "prepare": "npm run build",
@@ -35,13 +34,13 @@
     "@theledger/fabric-chaincode-utils": "^4.0.1",
     "@worldsibu/convector-core": "1.2.0",
     "@worldsibu/convector-storage-stub": "1.2.0",
-    "pm2": "^3.4.0",
     "reflect-metadata": "^0.1.12",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
     "http-server": "^0.11.1",
     "mocha": "^5.0.3",
+    "nodemon": "^1.18.10",
     "npm-scripts-watcher": "^1.0.2",
     "rimraf": "^2.6.2",
     "ts-node": "^6.0.3",

--- a/@worldsibu/convector-core-chaincode/src/chaincode-tx.ts
+++ b/@worldsibu/convector-core-chaincode/src/chaincode-tx.ts
@@ -1,7 +1,19 @@
+import { Schema, object } from 'yup';
 import { ClientIdentity } from 'fabric-shim';
 import { StubHelper } from '@theledger/fabric-chaincode-utils';
 
-export abstract class ChaincodeTx {
-  stub: StubHelper;
-  identity: ClientIdentity;
+/** @hidden */
+const isSchema = (schema: any): schema is Schema<any> => 'validate' in schema;
+
+export class ChaincodeTx {
+  constructor(public stub: StubHelper, public identity: ClientIdentity) { }
+
+  public getTransientValue<T>(name: string, validator: Schema<T>|{ new (...args): T}): Promise<T> {
+    const schema = isSchema(validator) ? validator : object()
+      .transform(value => value instanceof validator ? value : new validator(value));
+
+    const transient = this.stub.getStub().getTransient();
+    const transientValue = transient.get(name).toString('utf8');
+    return schema.validate(transientValue) as Promise<T>;
+  }
 }

--- a/@worldsibu/convector-core-chaincode/src/config.ts
+++ b/@worldsibu/convector-core-chaincode/src/config.ts
@@ -6,7 +6,7 @@ import {
   ControllerMissingError,
   ConfigurationParseError,
   ConfigurationFileOpenError
-} from '@worldsibu/convector-core-errors';
+} from '@worldsibu/convector-core';
 
 /** Model for the controller configuration */
 export interface IConfig {

--- a/@worldsibu/convector-core-chaincode/tests/ccc/index.ts
+++ b/@worldsibu/convector-core-chaincode/tests/ccc/index.ts
@@ -1,9 +1,17 @@
-import { ConvectorController, Controller, Invokable, Param } from '@worldsibu/convector-core-controller';
+import * as yup from 'yup';
+import { ConvectorController, Controller, Invokable } from '@worldsibu/convector-core';
+
+import { ChaincodeTx } from '../..';
 
 @Controller('test')
-export class TestController extends ConvectorController {
+export class TestController extends ConvectorController<ChaincodeTx> {
   @Invokable()
   public async test() {
     // EMPTY
+  }
+
+  @Invokable()
+  public async testTransient() {
+    return this.tx.getTransientValue('test', yup.string());
   }
 }

--- a/@worldsibu/convector-core-chaincode/tests/chaincode.spec.ts
+++ b/@worldsibu/convector-core-chaincode/tests/chaincode.spec.ts
@@ -30,11 +30,17 @@ describe('Generic Chaincode', () => {
     });
 
     it('should invoke a controller', async () => {
-      const id = 'Sibu';
-
       const response = await stub.mockInvoke(uuid(), ['test_test']);
-
       expect(response.status).to.eql(200);
+    });
+
+    it('should work with transient data', async () => {
+      const transient = new Map<string, Buffer>();
+      transient.set('test', Buffer.from('Transient'));
+
+      const response = await stub.mockInvoke(uuid(), ['test_testTransient'], transient);
+
+      expect(JSON.parse(response.payload.toString('utf8'))).to.eql('Transient');
     });
   });
 });

--- a/@worldsibu/convector-core-errors/src/chaincode.errors.ts
+++ b/@worldsibu/convector-core-errors/src/chaincode.errors.ts
@@ -26,3 +26,16 @@ export class ChaincodeInvokationError extends BaseError {
     this.message = super.getMessage(super.getOriginal());
   }
 }
+
+export class ChaincodeInvalidTransientError extends BaseError {
+  public code = 'CC_INV_TRANS_ERR';
+  public description = 'Invalid transient value for function';
+  public explanation = `
+    There was an error while trying to parse the transient data using value ${this.value}
+    ${chaincodeSideMessage}`;
+
+  constructor(public original: Error, public value: any) {
+    super();
+    this.message = super.getMessage(super.getOriginal());
+  }
+}

--- a/@worldsibu/convector-core-model/src/convector-model.ts
+++ b/@worldsibu/convector-core-model/src/convector-model.ts
@@ -58,10 +58,11 @@ export abstract class ConvectorModel<T extends ConvectorModel<any>> {
   public static async getOne<T extends ConvectorModel<any>>(
     this: new (content: any) => T,
     id: string,
-    type?: new (content: any) => T
+    type?: new (content: any) => T,
+    storageOptions?: any
   ): Promise<T> {
     type = type || this;
-    const content = await BaseStorage.current.get(id);
+    const content = await BaseStorage.current.get(id, storageOptions);
 
     const model = new type(content);
 
@@ -162,8 +163,8 @@ export abstract class ConvectorModel<T extends ConvectorModel<any>> {
   /**
    * Invokes the [[BaseStorage.get]] method to retrieve the model from storage.
    */
-  public async fetch() {
-    const content = await BaseStorage.current.get(this.id) as ConvectorModel<T>;
+  public async fetch(storageOptions?: any) {
+    const content = await BaseStorage.current.get(this.id, storageOptions) as ConvectorModel<T>;
 
     if (content.type !== this.type) {
       throw new Error(`Possible ID collision, element ${this.id} of type ${content.type} is not ${this.type}`);
@@ -184,8 +185,10 @@ export abstract class ConvectorModel<T extends ConvectorModel<any>> {
 
   /**
    * Invokes the [[BaseStorage.set]] method to write into chaincode.
+   *
+   * @param storageOptions Extra options to pass to the storage layer. The type depends on the storage
    */
-  public async save() {
+  public async save(storageOptions?: any) {
     this.assign(getDefaults(this), true);
     if (!ensureRequired(this)) {
       if (!this.id) {
@@ -197,7 +200,7 @@ export abstract class ConvectorModel<T extends ConvectorModel<any>> {
     }
 
     InvalidIdError.test(this.id);
-    await BaseStorage.current.set(this.id, this);
+    await BaseStorage.current.set(this.id, this, storageOptions);
   }
 
   /**
@@ -263,8 +266,8 @@ export abstract class ConvectorModel<T extends ConvectorModel<any>> {
    * Notice that there's no such a concept as **delete** in the blockchain,
    * so what this does is to remove all the reachable references to the model.
    */
-  public async delete() {
-    await BaseStorage.current.delete(this.id);
+  public async delete(storageOptions?: any) {
+    await BaseStorage.current.delete(this.id, storageOptions);
   }
 
   /**

--- a/@worldsibu/convector-core-storage/src/base-storage.ts
+++ b/@worldsibu/convector-core-storage/src/base-storage.ts
@@ -13,9 +13,9 @@ export abstract class BaseStorage {
     g.ConvectorBaseStorageCurrent = storage;
   }
 
-  public async abstract get(id: string): Promise<any>;
-  public async abstract set(id: string, content: any);
-  public async abstract delete(id: string);
+  public async abstract get(id: string, storageOptions?: any): Promise<any>;
+  public async abstract set(id: string, content: any, storageOptions?: any);
+  public async abstract delete(id: string, storageOptions?: any);
   public async abstract query(...args: any[]): Promise<any[]>;
   public async abstract history(id: string): Promise<any[]>;
 }

--- a/@worldsibu/convector-storage-couchdb/package.json
+++ b/@worldsibu/convector-storage-couchdb/package.json
@@ -27,8 +27,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core-errors": "1.2.0",
-    "@worldsibu/convector-core-storage": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "node-couchdb": "^1.3.0",
     "tslib": "^1.9.0"
   },

--- a/@worldsibu/convector-storage-couchdb/src/couchdb-storage.ts
+++ b/@worldsibu/convector-storage-couchdb/src/couchdb-storage.ts
@@ -1,8 +1,7 @@
 /** @module @worldsibu/convector-storage-couchdb */
 
 import * as CouchDB from 'node-couchdb';
-import { InvalidIdError } from '@worldsibu/convector-core-errors';
-import { BaseStorage } from '@worldsibu/convector-core-storage';
+import { BaseStorage, InvalidIdError } from '@worldsibu/convector-core';
 
 export class CouchDBStorage extends BaseStorage {
   private couch: any;

--- a/@worldsibu/convector-storage-localstorage/package.json
+++ b/@worldsibu/convector-storage-localstorage/package.json
@@ -28,8 +28,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core-errors": "1.2.0",
-    "@worldsibu/convector-core-storage": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-storage-localstorage/src/locastorage-storage.ts
+++ b/@worldsibu/convector-storage-localstorage/src/locastorage-storage.ts
@@ -1,7 +1,6 @@
 /** @module @worldsibu/convector-storage-stub */
 
-import { BaseStorage } from '@worldsibu/convector-core-storage';
-import { InvalidIdError,  } from '@worldsibu/convector-core-errors';
+import { InvalidIdError, BaseStorage } from '@worldsibu/convector-core';
 
 export class LocalstorageStorage extends BaseStorage {
   constructor(public namespace = 'CONVECTOR_STORAGE') {

--- a/@worldsibu/convector-storage-stub/package.json
+++ b/@worldsibu/convector-storage-stub/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "@theledger/fabric-chaincode-utils": "^4.0.1",
     "@theledger/fabric-shim-crypto-types": "^1.0.5",
-    "@worldsibu/convector-core-errors": "1.2.0",
-    "@worldsibu/convector-core-storage": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-storage-stub/src/stub-storage.ts
+++ b/@worldsibu/convector-storage-stub/src/stub-storage.ts
@@ -1,8 +1,7 @@
 /** @module @worldsibu/convector-storage-stub */
 
 import { ChaincodeStub } from 'fabric-shim';
-import { BaseStorage } from '@worldsibu/convector-core-storage';
-import { InvalidIdError } from '@worldsibu/convector-core-errors';
+import { BaseStorage, InvalidIdError } from '@worldsibu/convector-core';
 import { StubHelper, Transform } from '@theledger/fabric-chaincode-utils';
 
 // Remove when this gets merged
@@ -22,18 +21,28 @@ export class StubStorage extends BaseStorage {
     return await this.stubHelper.getQueryResultAsList(query);
   }
 
-  public async get(id: string): Promise<any> {
+  /**
+   * storageOptions parameter correspond to the StubHelper param
+   * @see https://wearetheledger.github.io/fabric-node-chaincode-utils/modules/_models_getstateoptions_.html
+   */
+  public async get(id: string, storageOptions?: any): Promise<any> {
     InvalidIdError.test(id);
-    return await this.stubHelper.getStateAsObject(id);
+    return await this.stubHelper.getStateAsObject(id, storageOptions);
   }
 
-  public async set(id: string, content: any) {
+  public async set(id: string, content: any, storageOptions?: any) {
     InvalidIdError.test(id);
-    return await this.stubHelper.putState(id, JSON.stringify(content));
+    return await this.stubHelper.putState(id, JSON.stringify(content), storageOptions);
   }
 
-  public async delete(id: string) {
+  public async delete(id: string, storageOptions: any = {}) {
     InvalidIdError.test(id);
+
+    if (storageOptions.privateCollection) {
+      return await this.stubHelper.getStub()
+        .deletePrivateData(storageOptions.privateCollection, id);
+    }
+
     return await this.stubHelper.getStub().deleteState(id);
   }
 

--- a/@worldsibu/convector-tool-chaincode-manager/package.json
+++ b/@worldsibu/convector-tool-chaincode-manager/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "@worldsibu/convector-common-fabric-helper": "1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
     "@worldsibu/convector-core-chaincode": "1.2.0",
-    "@worldsibu/convector-core-errors": "1.2.0",
     "commander": "^2.15.1",
     "docker-composer-manager": "^0.1.3",
     "fs-extra": "^6.0.1",

--- a/examples/token/package.json
+++ b/examples/token/package.json
@@ -16,15 +16,15 @@
     "client:generate": "node ./node_modules/@worldsibu/convector-core-adapter/dist/src/generate-interface -c TokenController"
   },
   "dependencies": {
-    "@worldsibu/convector-core": "^1.2.0",
-    "@worldsibu/convector-platform-fabric": "^1.2.0",
+    "@worldsibu/convector-core": "1.2.0",
+    "@worldsibu/convector-platform-fabric": "1.2.0",
     "reflect-metadata": "^0.1.12",
     "tslib": "^1.9.0",
     "yup": "^0.26.10"
   },
   "devDependencies": {
-    "@worldsibu/convector-adapter-mock": "^1.2.0",
-    "@worldsibu/convector-storage-couchdb": "^1.2.0",
+    "@worldsibu/convector-adapter-mock": "1.2.0",
+    "@worldsibu/convector-storage-couchdb": "1.2.0",
     "mocha": "^5.0.3",
     "rimraf": "^2.6.2",
     "ts-node": "^6.0.3",

--- a/examples/token/src/token.controller.ts
+++ b/examples/token/src/token.controller.ts
@@ -66,7 +66,7 @@ export class TokenController extends ConvectorController<ChaincodeTx> {
       throw new Error(`No token found with id ${tokenId}`);
     }
 
-    return token;
+    return token.toJSON();
   }
 
   @Invokable()


### PR DESCRIPTION
## Proposed changes

Closes #66

APIs to send and receive transient and private data for HLF. This also involves the ability to send query transaction which wasn't possible with convector before.
Adapters now follow a more flexible approach, allowing to pass a `$config(...)` object on each transaction, this is necessary for metadata handling on each adapter.
Storages also allow to pass metadata on save, delete and get operations, useful for example on the stub-storage to decide if it's a regular operation or a private data operation.

## Types of changes

What types of changes does your code introduce to Convector?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Get the transient data inside a controller
```ts
const data = await this.tx.getTransientValue<MyModel>('transient-key', MyModel);
const primitive = await this.tx.getTransientValue('my-custom-key', yup.string());
```

### Write and read from a private collection
```ts
await myModelInstance.save({ privateCollection: 'my-private-collection' });
const data = await MyModel.getOne(id, MyModel, { privateCollection: 'my-private-collection' });
```

### Send transient data from a consumer
```ts
await myCtrlClient.$config({ transient: {'transient-key': someModel.toJSON()} }).myCtrlFunction();
await myCtrlClient.$config({ transient: {'my-custom-key': 'some value'} }).anotherCtrlFunction();
```

### Send query transaction
Not related to private data, but necessary since not all the peers will respond with data, some of them might not have access to the private data, so we needed a way to send a TX and return success if at least one response was OK.
This will send a tx to all the query peers, never send that tx to the orderer, and if at least one response is success, Convector will return data.
```ts
const data = await myCtrlClient.$query().myCtrlMethod();
```