### PR TITLE
fix: chaincode nodemon dependency for debug

### DIFF
--- a/@worldsibu/convector-core-chaincode/package.json
+++ b/@worldsibu/convector-core-chaincode/package.json
@@ -37,10 +37,12 @@
     "reflect-metadata": "^0.1.12",
     "tslib": "^1.9.0"
   },
+  "chaincodeDevDependencies": {
+    "nodemon": "^1.18.10"
+  },
   "devDependencies": {
     "http-server": "^0.11.1",
     "mocha": "^5.0.3",
-    "nodemon": "^1.18.10",
     "npm-scripts-watcher": "^1.0.2",
     "rimraf": "^2.6.2",
     "ts-node": "^6.0.3",

--- a/@worldsibu/convector-tool-chaincode-manager/src/manager.ts
+++ b/@worldsibu/convector-tool-chaincode-manager/src/manager.ts
@@ -184,6 +184,7 @@ export class Manager extends ClientHelper {
 
     delete pkg.watch;
     delete pkg.devDependencies;
+    pkg.devDependencies = pkg.chaincodeDevDependencies || {};
 
     const packagesFolderPath = join(output, 'packages');
 


### PR DESCRIPTION
## Proposed changes

The devDependencies get deleted in the chaincode package. We need to keep nodemon for debug

## Types of changes

What types of changes does your code introduce to Convector?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
