### PR TITLE
error handler spec and e2e

### DIFF
--- a/@worldsibu/convector-adapter-browser/package.json
+++ b/@worldsibu/convector-adapter-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-adapter-browser",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Controller adapter to use as a mock in browser",
   "license": "Apache-2.0",
   "repository": {
@@ -28,7 +28,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-adapter-fabric/package.json
+++ b/@worldsibu/convector-adapter-fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-adapter-fabric",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Controller adapter to use with fabric-client SDK",
   "license": "Apache-2.0",
   "repository": {
@@ -31,8 +31,8 @@
     "fabric-client": ">=1.1.2"
   },
   "dependencies": {
-    "@worldsibu/convector-common-fabric-helper": "^1.3.0",
-    "@worldsibu/convector-core": "^1.3.0",
+    "@worldsibu/convector-common-fabric-helper": "^1.3.1",
+    "@worldsibu/convector-core": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-adapter-fabric/src/fabric.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric/src/fabric.controller-adapter.ts
@@ -1,6 +1,6 @@
 /** @module @worldsibu/convector-adapter-fabric */
 
-import { ControllerAdapter } from '@worldsibu/convector-core';
+import { ControllerAdapter, ClientResponseError } from '@worldsibu/convector-core';
 import { ClientHelper, ClientConfig, TxResult } from '@worldsibu/convector-common-fabric-helper';
 
 export { TxResult };
@@ -15,8 +15,32 @@ export class FabricControllerAdapter extends ClientHelper implements ControllerA
   }
 
   public async invoke(controller: string, name: string, config?: any, ...args: any[]): Promise<any> {
-    const txResult = await super.invoke(`${controller}_${name}`, this.config.chaincode, config, ...args);
-    return txResult.result;
+    try {
+      const txResult = await super.invoke(`${controller}_${name}`, this.config.chaincode, config, ...args);
+      return txResult.result;
+    } catch (err) {
+      if (!err.responses) {
+        throw err;
+      }
+
+      let errors: any;
+
+      try {
+        errors = err.responses
+          .map(response => ({
+            response,
+            error: JSON.parse(Buffer.from(JSON.parse(
+              response.message.replace(/^.+\{/, '{')
+            )).toString('utf8'))
+          }));
+      } catch (err) {
+        throw new ClientResponseError(err.responses.map(error => ({
+          error
+        })));
+      }
+
+      throw new ClientResponseError(errors);
+    }
   }
 
   public async query(controller: string, name: string, config?: any, ...args: any[]): Promise<any> {

--- a/@worldsibu/convector-adapter-mock/package.json
+++ b/@worldsibu/convector-adapter-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-adapter-mock",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Controller adapter to use as a mock in unit tests",
   "license": "Apache-2.0",
   "repository": {
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@theledger/fabric-mock-stub": "^4.0.0",
-    "@worldsibu/convector-core": "^1.3.0",
-    "@worldsibu/convector-core-chaincode": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
+    "@worldsibu/convector-core-chaincode": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-common-fabric-helper/package.json
+++ b/@worldsibu/convector-common-fabric-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-common-fabric-helper",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector helper library for fabric communication",
   "license": "Apache-2.0",
   "repository": {

--- a/@worldsibu/convector-core-adapter/package.json
+++ b/@worldsibu/convector-core-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core-adapter",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Chaincode Base Storage class. This is not intended to be used as a provider but as an abstract interface of one",
   "license": "Apache-2.0",
   "repository": {
@@ -34,8 +34,8 @@
     "reflect-metadata": ">=0.1.12"
   },
   "dependencies": {
-    "@worldsibu/convector-core-controller": "^1.3.0",
-    "@worldsibu/convector-core-errors": "^1.3.0",
+    "@worldsibu/convector-core-controller": "^1.3.1",
+    "@worldsibu/convector-core-errors": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "optionalDependencies": {

--- a/@worldsibu/convector-core-chaincode/package.json
+++ b/@worldsibu/convector-core-chaincode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core-chaincode",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector base chaincode to use in conjunction with controllers and models",
   "license": "Apache-2.0",
   "repository": {
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@theledger/fabric-chaincode-utils": "^4.0.1",
-    "@worldsibu/convector-core": "^1.3.0",
-    "@worldsibu/convector-storage-stub": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
+    "@worldsibu/convector-storage-stub": "^1.3.1",
     "reflect-metadata": "^0.1.12",
     "tslib": "^1.9.0"
   },

--- a/@worldsibu/convector-core-chaincode/src/chaincode.ts
+++ b/@worldsibu/convector-core-chaincode/src/chaincode.ts
@@ -60,7 +60,7 @@ export class Chaincode extends CC {
       await this.initControllers(new StubHelper(stub), [, 'true']);
       const invokeRes = await super.Invoke(stub);
       if (invokeRes.status === 500) {
-        return error(Buffer.from(JSON.stringify(invokeRes.message)));
+        return error(Buffer.from(JSON.stringify(invokeRes.message.toString())));
       }
       return invokeRes;
     } catch (e) {

--- a/@worldsibu/convector-core-controller/package.json
+++ b/@worldsibu/convector-core-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core-controller",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector Controller base class",
   "license": "Apache-2.0",
   "repository": {
@@ -37,8 +37,8 @@
     "reflect-metadata": ">=0.1.12"
   },
   "dependencies": {
-    "@worldsibu/convector-core-errors": "^1.3.0",
-    "@worldsibu/convector-core-model": "^1.3.0",
+    "@worldsibu/convector-core-errors": "^1.3.1",
+    "@worldsibu/convector-core-model": "^1.3.1",
     "tslib": "^1.9.0",
     "yup": "^0.26.10"
   },

--- a/@worldsibu/convector-core-errors/package.json
+++ b/@worldsibu/convector-core-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core-errors",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector Errors",
   "license": "Apache-2.0",
   "repository": {

--- a/@worldsibu/convector-core-errors/src/client.errors.ts
+++ b/@worldsibu/convector-core-errors/src/client.errors.ts
@@ -1,0 +1,20 @@
+/** @module @worldsibu/convector-core-errors */
+
+import { BaseError } from './base.error';
+import { chaincodeSideMessage } from './common';
+
+export interface ClientChaincodeResponse {
+  error?: any;
+  response?: any;
+}
+
+export class ClientResponseError extends BaseError {
+  public code = 'CLIENT_RES_ERR';
+  public description = 'There was a problem while invoking the chaincode';
+  public explanation = `Chaincode error, this is a wrapper around the responses`;
+
+  constructor(public responses: ClientChaincodeResponse[]) {
+    super();
+    this.message = super.getMessage(super.getOriginal());
+  }
+}

--- a/@worldsibu/convector-core-errors/src/index.ts
+++ b/@worldsibu/convector-core-errors/src/index.ts
@@ -1,5 +1,6 @@
 export * from './id.errors';
 export * from './type.errors';
+export * from './client.errors';
 export * from './chaincode.errors';
 export * from './controller.errors';
 export * from './configuration.errors';

--- a/@worldsibu/convector-core-model/package.json
+++ b/@worldsibu/convector-core-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core-model",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector Model base class",
   "license": "Apache-2.0",
   "repository": {
@@ -37,8 +37,8 @@
     "reflect-metadata": ">=0.1.12"
   },
   "dependencies": {
-    "@worldsibu/convector-core-errors": "^1.3.0",
-    "@worldsibu/convector-core-storage": "^1.3.0",
+    "@worldsibu/convector-core-errors": "^1.3.1",
+    "@worldsibu/convector-core-storage": "^1.3.1",
     "tslib": "^1.9.0",
     "yup": "^0.26.10"
   },

--- a/@worldsibu/convector-core-storage/package.json
+++ b/@worldsibu/convector-core-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core-storage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector Core Storage class. This is not intended to be used as a provider but as an abstract interface of one",
   "license": "Apache-2.0",
   "repository": {
@@ -27,7 +27,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core-errors": "^1.3.0",
+    "@worldsibu/convector-core-errors": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-core/package.json
+++ b/@worldsibu/convector-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector core packages",
   "license": "Apache-2.0",
   "repository": {
@@ -28,11 +28,11 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core-adapter": "^1.3.0",
-    "@worldsibu/convector-core-controller": "^1.3.0",
-    "@worldsibu/convector-core-errors": "^1.3.0",
-    "@worldsibu/convector-core-model": "^1.3.0",
-    "@worldsibu/convector-core-storage": "^1.3.0",
+    "@worldsibu/convector-core-adapter": "^1.3.1",
+    "@worldsibu/convector-core-controller": "^1.3.1",
+    "@worldsibu/convector-core-errors": "^1.3.1",
+    "@worldsibu/convector-core-model": "^1.3.1",
+    "@worldsibu/convector-core-storage": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-platform-browser/package.json
+++ b/@worldsibu/convector-platform-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-platform-browser",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector packages for browser support",
   "license": "Apache-2.0",
   "repository": {
@@ -28,8 +28,8 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-adapter-browser": "^1.3.0",
-    "@worldsibu/convector-storage-localstorage": "^1.3.0",
+    "@worldsibu/convector-adapter-browser": "^1.3.1",
+    "@worldsibu/convector-storage-localstorage": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-platform-fabric/package.json
+++ b/@worldsibu/convector-platform-fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-platform-fabric",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector packages for fabric support",
   "license": "Apache-2.0",
   "repository": {
@@ -28,11 +28,11 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-adapter-fabric": "^1.3.0",
-    "@worldsibu/convector-common-fabric-helper": "^1.3.0",
-    "@worldsibu/convector-core-chaincode": "^1.3.0",
-    "@worldsibu/convector-storage-stub": "^1.3.0",
-    "@worldsibu/convector-tool-chaincode-manager": "^1.3.0",
+    "@worldsibu/convector-adapter-fabric": "^1.3.1",
+    "@worldsibu/convector-common-fabric-helper": "^1.3.1",
+    "@worldsibu/convector-core-chaincode": "^1.3.1",
+    "@worldsibu/convector-storage-stub": "^1.3.1",
+    "@worldsibu/convector-tool-chaincode-manager": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-storage-couchdb/package.json
+++ b/@worldsibu/convector-storage-couchdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-storage-couchdb",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector CouchDB Storage class",
   "license": "Apache-2.0",
   "repository": {
@@ -27,7 +27,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
     "node-couchdb": "^1.3.0",
     "tslib": "^1.9.0"
   },

--- a/@worldsibu/convector-storage-localstorage/package.json
+++ b/@worldsibu/convector-storage-localstorage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-storage-localstorage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector localstorage Storage class",
   "license": "Apache-2.0",
   "repository": {
@@ -28,7 +28,7 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-core": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-storage-stub/package.json
+++ b/@worldsibu/convector-storage-stub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-storage-stub",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector STUB Storage class",
   "license": "Apache-2.0",
   "repository": {
@@ -30,7 +30,7 @@
   "dependencies": {
     "@theledger/fabric-chaincode-utils": "^4.0.1",
     "@theledger/fabric-shim-crypto-types": "^1.0.5",
-    "@worldsibu/convector-core": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
     "tslib": "^1.9.0"
   },
   "devDependencies": {

--- a/@worldsibu/convector-tool-chaincode-manager/package.json
+++ b/@worldsibu/convector-tool-chaincode-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-tool-chaincode-manager",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Chaincode manager to install and run chaincodes",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",
@@ -30,9 +30,9 @@
     "docs:serve": "http-server docs"
   },
   "dependencies": {
-    "@worldsibu/convector-common-fabric-helper": "^1.3.0",
-    "@worldsibu/convector-core": "^1.3.0",
-    "@worldsibu/convector-core-chaincode": "^1.3.0",
+    "@worldsibu/convector-common-fabric-helper": "^1.3.1",
+    "@worldsibu/convector-core": "^1.3.1",
+    "@worldsibu/convector-core-chaincode": "^1.3.1",
     "commander": "^2.15.1",
     "docker-composer-manager": "^0.1.3",
     "fs-extra": "^6.0.1",

--- a/@worldsibu/convector-tool-dev-env/package.json
+++ b/@worldsibu/convector-tool-dev-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-tool-dev-env",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Development environment",
   "main": "./dist/index.js",
   "license": "Apache-2.0",
@@ -41,7 +41,7 @@
     "fabric-client": ">=1.1.2"
   },
   "dependencies": {
-    "@worldsibu/convector-common-fabric-helper": "^1.3.0",
+    "@worldsibu/convector-common-fabric-helper": "^1.3.1",
     "commander": "^2.15.1",
     "shelljs": "^0.8.2",
     "tslib": "^1.9.0"

--- a/examples/token/package.json
+++ b/examples/token/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@worldsibu/convector-example-token",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Convector Token Example",
   "license": "ISC",
   "main": "./dist/src/index.js",
@@ -16,15 +16,15 @@
     "client:generate": "node ./node_modules/@worldsibu/convector-core-adapter/dist/src/generate-interface -c TokenController"
   },
   "dependencies": {
-    "@worldsibu/convector-core": "^1.3.0",
-    "@worldsibu/convector-platform-fabric": "^1.3.0",
+    "@worldsibu/convector-core": "^1.3.1",
+    "@worldsibu/convector-platform-fabric": "^1.3.1",
     "reflect-metadata": "^0.1.12",
     "tslib": "^1.9.0",
     "yup": "^0.26.10"
   },
   "devDependencies": {
-    "@worldsibu/convector-adapter-mock": "^1.3.0",
-    "@worldsibu/convector-storage-couchdb": "^1.3.0",
+    "@worldsibu/convector-adapter-mock": "^1.3.1",
+    "@worldsibu/convector-storage-couchdb": "^1.3.1",
     "mocha": "^5.0.3",
     "rimraf": "^2.6.2",
     "ts-node": "^6.0.3",

--- a/examples/token/tests/token.e2e.ts
+++ b/examples/token/tests/token.e2e.ts
@@ -80,6 +80,16 @@ describe('Token e2e', () => {
     expect(token.balances[certificate]).to.eq(500000);
   });
 
+  it('should fail expectedly', async () => {
+    try {
+      await tokenCtrl.failMe();
+    } catch (error) {
+      expect(error.responses).to.exist;
+      expect(error.responses).to.be.of.lengthOf(2);
+      expect(error.responses[0].error.message).to.eql('Expected to fail');
+    }
+  });
+
   it('should retrieve a token', async () => {
     const token = await tokenCtrl.get(tokenId);
     expect(token.balances[certificate]).to.eq(500000);

--- a/examples/token/tests/token.spec.ts
+++ b/examples/token/tests/token.spec.ts
@@ -65,8 +65,13 @@ describe('Token', () => {
   });
 
   it('should fail expectedly', async () => {
-    await expect(tokenCtrl.failMe()).to.be.eventually
-      .rejectedWith('Expected to fail');
+    try {
+      await tokenCtrl.failMe();
+    } catch (error) {
+      expect(error.responses).to.exist;
+      expect(error.responses).to.be.of.lengthOf(1);
+      expect(error.responses[0].error.message).to.eql('Expected to fail');
+    }
   });
 
   it('should retrieve a token', async () => {

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,7 @@
     "@worldsibu/*",
     "examples/*"
   ],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "command": {
     "bootstrap": {
       "hoist": true


### PR DESCRIPTION
## Proposed changes

Normalized the error handlers across unit tests and fabric transactions to use the same interface for errors. Before this errors were different on each platform, but this PR introduces the `ClientResponseError` containing all the error information available.

## Types of changes

What types of changes does your code introduce to Convector?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Errors have a `responses` field containing on each the error from a single response. With the MockAdapter there's just one response. With the FabricAdapter there's one response per peer in the request.

```ts
try {
  await tokenCtrl.failMe();
} catch (error) {
  expect(error.responses).to.exist;
  expect(error.responses).to.be.of.lengthOf(1);
  expect(error.responses[0].error.message).to.eql('Expected to fail');
}
```