### PR TITLE
Inter chaincode invokations

### DIFF
--- a/@worldsibu/convector-adapter-fabric-in-chaincode/LICENSE.txt
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/LICENSE.txt
@@ -1,0 +1,203 @@
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/package-lock.json
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/package-lock.json
@@ -1,0 +1,11 @@
+{
+	"requires": true,
+	"lockfileVersion": 1,
+	"dependencies": {
+		"typescript": {
+			"version": "2.8.3",
+			"resolved": "https://repo.artifacts.weather.com/api/npm/web-decoupling-npm-virtual/typescript/-/typescript-2.8.3.tgz",
+			"integrity": "sha1-XYF/m28xu4cYNfTt8AifIavmwXA="
+		}
+	}
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/package.json
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@worldsibu/convector-adapter-fabric-in-chaincode",
+  "version": "1.3.3",
+  "description": "Controller adapter to inside chaincode transactions to invoke another chaincode",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hyperledger-labs/convector/tree/develop/%40worldsibu/convector-adapter-fabric"
+  },
+  "homepage": "https://worldsibu.tech/convector/convector-smart-contracts/",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
+  "files": [
+    "dist/*"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rimraf dist",
+    "clean:docs": "rimraf docs",
+    "build": "npm run clean && tsc",
+    "prepare": "npm run build",
+    "lint": "tslint --fix -c '../../tslint.json' -p './tsconfig.json'",
+    "test": "mocha -r ts-node/register test/**/*.spec.ts --reporter spec",
+    "predocs:generate": "npm run clean:docs",
+    "docs:generate": "typedoc src --mode file --out docs --target ES6 --excludePrivate",
+    "docs:serve": "http-server docs"
+  },
+  "peerDependencies": {
+    "fabric-ca-client": ">=1.1.2",
+    "fabric-client": ">=1.1.2"
+  },
+  "dependencies": {
+    "@worldsibu/convector-core": "^1.3.3",
+    "@worldsibu/convector-core-chaincode": "^1.3.3",
+    "@worldsibu/convector-storage-stub": "^1.3.3",
+    "tslib": "^1.9.0"
+  },
+  "devDependencies": {
+    "@worldsibu/convector-adapter-mock": "^1.3.3",
+    "http-server": "^0.11.1",
+    "mocha": "^5.0.3",
+    "npm-scripts-watcher": "^1.0.2",
+    "rimraf": "^2.6.2",
+    "ts-node": "^6.0.3",
+    "tslint": "^5.9.1",
+    "typedoc": "^0.11.1",
+    "typescript": "2.8.3"
+  }
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
@@ -1,0 +1,36 @@
+import { StubStorage } from '@worldsibu/convector-storage-stub';
+import { ChaincodeTx } from '@worldsibu/convector-core-chaincode';
+import { ControllerAdapter, BaseStorage } from '@worldsibu/convector-core';
+
+export interface InChaincodeAdapterConfig {
+  tx?: ChaincodeTx;
+  chaincode?: string;
+  channel?: string;
+}
+
+export class InChaincodeAdapter implements ControllerAdapter {
+
+  public async invoke(controller: string, name: string, config: InChaincodeAdapterConfig = {}, ...args: any[]) {
+    return this.rawInvoke(`${controller}_${name}`, config, ...args);
+  }
+
+  public async rawInvoke(fn: string, config: InChaincodeAdapterConfig = {}, ...args: any[]) {
+    if (!config.tx) {
+      throw new Error('InChaincodeAdapter needs the ChaincodeTx in config');
+    }
+
+    if (!config.chaincode) {
+      throw new Error('InChaincodeAdapter needs a stub in config');
+    }
+
+    const stub = config.tx.stub.getStub();
+    const res = await stub.invokeChaincode(config.chaincode, [fn, ...args], config.channel);
+    const storage = BaseStorage.current as StubStorage;
+
+    // Make sure the stub is still the same
+    // On unit tests it might change the context for the subsecuent calls
+    storage.stubHelper = config.tx.stub;
+
+    return JSON.parse(res.payload.toString('utf8'));
+  }
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/index.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/index.ts
@@ -1,0 +1,1 @@
+export * from './fabric-in-chaincode.controller-adapter';

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/test/fabric-in-chaincode.controller-adapter.spec.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/test/fabric-in-chaincode.controller-adapter.spec.ts
@@ -1,0 +1,81 @@
+// tslint:disable:no-unused-expression
+
+import { join } from 'path';
+import { expect } from 'chai';
+import 'mocha';
+import 'reflect-metadata';
+
+import { MockControllerAdapter } from '@worldsibu/convector-adapter-mock';
+import { ConvectorControllerClient, ClientFactory } from '@worldsibu/convector-core';
+
+import { FirstController } from './first-cc';
+import { SecondController, Second } from './second-cc';
+import { ThirdController, Third } from './third-cc';
+
+describe('In Chaincode Controller Adapter', () => {
+  let firstAdapter: MockControllerAdapter;
+  let firstCtrl: ConvectorControllerClient<FirstController>;
+
+  let secondAdapter: MockControllerAdapter;
+  let secondCtrl: ConvectorControllerClient<SecondController>;
+
+  let thirdAdapter: MockControllerAdapter;
+  let thirdCtrl: ConvectorControllerClient<ThirdController>;
+
+  before(async () => {
+    firstAdapter = new MockControllerAdapter();
+    firstCtrl = ClientFactory(FirstController, firstAdapter);
+    await firstAdapter.init([
+      {
+        version: '*',
+        controller: 'FirstController',
+        name: join(__dirname, 'first-cc')
+      }
+    ]);
+
+    secondAdapter = new MockControllerAdapter();
+    secondCtrl = ClientFactory(SecondController, secondAdapter);
+    await secondAdapter.init([
+      {
+        version: '*',
+        controller: 'SecondController',
+        name: join(__dirname, 'second-cc')
+      }
+    ]);
+
+    thirdAdapter = new MockControllerAdapter();
+    thirdCtrl = ClientFactory(ThirdController, thirdAdapter);
+    await thirdAdapter.init([
+      {
+        version: '*',
+        controller: 'ThirdController',
+        name: join(__dirname, 'third-cc')
+      }
+    ]);
+
+    firstAdapter.stub.mockPeerChaincode('second/ch1', secondAdapter.stub);
+    firstAdapter.stub.mockPeerChaincode('third/ch1', thirdAdapter.stub);
+  });
+
+  it('it should invoke a function in another chaincode when you have the source code', async () => {
+    // Write in second and third chaincodes
+    // Even tho they have the same id, they are different chaincodes, so they won't override
+    await secondCtrl.init(new Second({
+      id: '1',
+      name: 'Casa'
+    }));
+
+    const second = await firstCtrl.connectToSecond('1', 'ch1', 'second');
+    expect(second.name).to.eql('Casa');
+  });
+
+  it('it should invoke a function in another chaincode when you don\'t have the source code', async () => {
+    await thirdCtrl.init(new Third({
+      id: '1',
+      name: 'Casita'
+    }));
+
+    const third = await firstCtrl.connectToThird('1', 'ch1', 'third');
+    expect(third.name).to.eql('Casita');
+  });
+});

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/test/first-cc.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/test/first-cc.ts
@@ -1,0 +1,58 @@
+import * as yup from 'yup';
+import {
+  Controller,
+  ConvectorController,
+  Invokable,
+  Param,
+  ClientFactory,
+  FlatConvectorModel
+} from '@worldsibu/convector-core';
+
+import { Third } from './third-cc';
+import { SecondController, Second } from './second-cc';
+import { InChaincodeAdapter } from '../src/fabric-in-chaincode.controller-adapter';
+
+const adapter = new InChaincodeAdapter();
+const secondCtrl = ClientFactory(SecondController, adapter);
+
+@Controller('first')
+export class FirstController extends ConvectorController {
+  @Invokable()
+  public async connectToSecond(
+    @Param(yup.string())
+    id: string,
+    @Param(yup.string())
+    channel: string,
+    @Param(yup.string())
+    chaincode: string
+  ): Promise<FlatConvectorModel<Second>> {
+    // Cross invoke the chaincode and return what it returns
+    // Do this when you have the source code of the external chaincode
+    const second = await secondCtrl.$config({ tx: this.tx, channel, chaincode }).get(id);
+    // Save the external model in this ledger
+    await new Second({id: `second:${id}`, ...second}).save();
+
+    // Return the model
+    return second;
+  }
+
+  @Invokable()
+  public async connectToThird(
+    @Param(yup.string())
+    id: string,
+    @Param(yup.string())
+    channel: string,
+    @Param(yup.string())
+    chaincode: string
+  ): Promise<FlatConvectorModel<Third>> {
+    // Cross invoke the chaincode and return what it returns
+    // Do this when you DON'T have the chaincode sourcecode, all you need is the name of the fn
+    const third = await adapter.rawInvoke('third_get', { tx: this.tx, channel, chaincode }, '1');
+
+    // Save the external model in this ledger
+    await new Third({id: `third:${id}`, ...third}).save();
+
+    // Return the model
+    return third;
+  }
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/test/second-cc.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/test/second-cc.ts
@@ -1,0 +1,36 @@
+import * as yup from 'yup';
+import {
+  Controller,
+  ConvectorController,
+  ConvectorModel,
+  FlatConvectorModel,
+  Invokable,
+  Param,
+  ReadOnly,
+  Required,
+  Validate
+} from '@worldsibu/convector-core';
+
+export class Second extends ConvectorModel<Second> {
+  @ReadOnly()
+  @Required()
+  public readonly type = 'io.worldsibu.second';
+
+  @Required()
+  @Validate(yup.string())
+  public name: string;
+}
+
+
+@Controller('second')
+export class SecondController extends ConvectorController {
+  @Invokable()
+  public async init(@Param(Second) data: Second): Promise<void> {
+    await data.save();
+  }
+
+  @Invokable()
+  public async get(@Param(yup.string()) id: string): Promise<FlatConvectorModel<Second>> {
+    return Second.getOne(id).then(m => m.toJSON()) as any;
+  }
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/test/third-cc.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/test/third-cc.ts
@@ -1,0 +1,36 @@
+import * as yup from 'yup';
+import {
+  Controller,
+  ConvectorController,
+  ConvectorModel,
+  FlatConvectorModel,
+  Invokable,
+  Param,
+  ReadOnly,
+  Required,
+  Validate
+} from '@worldsibu/convector-core';
+
+export class Third extends ConvectorModel<Third> {
+  @ReadOnly()
+  @Required()
+  public readonly type = 'io.worldsibu.third';
+
+  @Required()
+  @Validate(yup.string())
+  public name: string;
+}
+
+
+@Controller('third')
+export class ThirdController extends ConvectorController {
+  @Invokable()
+  public async init(@Param(Third) data: Third): Promise<void> {
+    await data.save();
+  }
+
+  @Invokable()
+  public async get(@Param(yup.string()) id: string): Promise<FlatConvectorModel<Third>> {
+    return Third.getOne(id).then(m => m.toJSON()) as any;
+  }
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/test/tsconfig.json
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": [
+    "./**/*"
+  ]
+}

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/tsconfig.json
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "./src/**/*"
+  ]
+}

--- a/@worldsibu/convector-storage-stub/src/stub-storage.ts
+++ b/@worldsibu/convector-storage-stub/src/stub-storage.ts
@@ -9,7 +9,7 @@ import { StubHelper, Transform } from '@theledger/fabric-chaincode-utils';
 Transform.isObject = data => data !== null && typeof data === 'object';
 
 export class StubStorage extends BaseStorage {
-  private stubHelper: StubHelper;
+  public stubHelper: StubHelper;
 
   constructor(stub: ChaincodeStub) {
     super();


### PR DESCRIPTION
## Proposed changes

To be able to invoke a chaincode from inside another chaincode using convector APIs. This was already possible using the stub object, but this ads some shortcuts to do it easily.

## Types of changes

What types of changes does your code introduce to Convector?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

From inside another controller you can make an invokation like this
```ts
const adapter = new InChaincodeAdapter();
const secondCtrl = ClientFactory(SecondController, adapter);
const second = await secondCtrl.$config({ tx: this.tx, 'channel-name', 'chaincode-name' }).get(id);
```
