### PR TITLE
fix: client error wrapper display the first error

### DIFF
--- a/@worldsibu/convector-core-errors/src/client.errors.ts
+++ b/@worldsibu/convector-core-errors/src/client.errors.ts
@@ -1,7 +1,6 @@
 /** @module @worldsibu/convector-core-errors */
 
 import { BaseError } from './base.error';
-import { chaincodeSideMessage } from './common';
 
 export interface ClientChaincodeResponse {
   error?: any;
@@ -15,6 +14,12 @@ export class ClientResponseError extends BaseError {
 
   constructor(public responses: ClientChaincodeResponse[]) {
     super();
-    this.message = super.getMessage(super.getOriginal());
+    const firstResWithErr = responses.find(res => res.error);
+    this.message = super.getMessage(firstResWithErr ?
+      firstResWithErr.error instanceof Error ?
+        firstResWithErr.error.stack :
+        JSON.stringify(firstResWithErr.error) :
+      this.getOriginal()
+    );
   }
 }


### PR DESCRIPTION
## Proposed changes

The client error wrapper is not currently showing the errors in the response. This PR changes that by printing the first error response

## Types of changes

What types of changes does your code introduce to Convector?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)