### PR TITLE
fix: handle global on browser environments

### DIFF
--- a/@worldsibu/convector-core-controller/package.json
+++ b/@worldsibu/convector-core-controller/package.json
@@ -53,6 +53,7 @@
     "@worldsibu/convector-core-errors": "^1.3.4",
     "@worldsibu/convector-core-model": "^1.3.4",
     "tslib": "^1.9.0",
+    "window-or-global": "^1.0.1",
     "yup": "^0.26.10"
   },
   "devDependencies": {

--- a/@worldsibu/convector-core-controller/src/controller.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/controller.decorator.ts
@@ -1,10 +1,8 @@
 /** @module convector-core-controller */
 
+import * as g from 'window-or-global';
 import { ControllerInvalidError } from '@worldsibu/convector-core-errors';
 import 'reflect-metadata';
-
-/** @hidden */
-const g: any = global;
 
 /** @hidden */
 export const controllerMetadataKey = g.ConvectorControllerMetadataKey || Symbol('controller');

--- a/@worldsibu/convector-core-controller/src/invokable.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/invokable.decorator.ts
@@ -1,6 +1,7 @@
 /** @module convector-core-controller */
 
 import { Schema } from 'yup';
+import * as g from 'window-or-global';
 import {
   ControllerNamespaceMissingError,
   ControllerInvokablesMissingError,
@@ -14,8 +15,6 @@ import 'reflect-metadata';
 import { paramMetadataKey } from './param.decorator';
 import { ConvectorController } from './convector-controller';
 import { controllerMetadataKey } from './controller.decorator';
-
-const g: any = global;
 
 /** @hidden */
 export const invokableMetadataKey = g.ConvectorInvokableMetadataKey || Symbol('invokable');

--- a/@worldsibu/convector-core-controller/src/param.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/param.decorator.ts
@@ -1,10 +1,8 @@
 /** @module convector-core-controller */
 
+import * as g from 'window-or-global';
 import { Schema, object } from 'yup';
 import 'reflect-metadata';
-
-/** @hidden */
-const g: any = global;
 
 /** @hidden */
 const isSchema = (schema: any): schema is Schema<any> => 'validate' in schema;

--- a/@worldsibu/convector-core-model/package.json
+++ b/@worldsibu/convector-core-model/package.json
@@ -53,6 +53,7 @@
     "@worldsibu/convector-core-errors": "^1.3.4",
     "@worldsibu/convector-core-storage": "^1.3.4",
     "tslib": "^1.9.0",
+    "window-or-global": "^1.0.1",
     "yup": "^0.26.10"
   },
   "devDependencies": {

--- a/@worldsibu/convector-core-model/src/default.decorator.ts
+++ b/@worldsibu/convector-core-model/src/default.decorator.ts
@@ -1,10 +1,10 @@
 /** @module convector-core-model */
 
-const g: any = global;
+import * as g from 'window-or-global';
+import 'reflect-metadata';
 
 export const defaultMetadataKey = g.ConvectorDefaultMetadataKey || Symbol('default');
 g.ConvectorDefaultMetadataKey = defaultMetadataKey;
-import 'reflect-metadata';
 
 export function Default<T>(defaultValue: T) {
   return (target: any, key: string) => {

--- a/@worldsibu/convector-core-model/src/required.decorator.ts
+++ b/@worldsibu/convector-core-model/src/required.decorator.ts
@@ -1,10 +1,10 @@
 /** @module convector-core-model */
 
-const g: any = global;
+import * as g from 'window-or-global';
+import 'reflect-metadata';
 
 export const requiredMetadataKey = g.ConvectorRequiredMetadataKey || Symbol('required');
 g.ConvectorRequiredMetadataKey = requiredMetadataKey;
-import 'reflect-metadata';
 
 export function Required() {
   return (target: any, key: string) => {

--- a/@worldsibu/convector-core-model/src/validate.decorator.ts
+++ b/@worldsibu/convector-core-model/src/validate.decorator.ts
@@ -2,9 +2,8 @@
 // tslint:disable:no-invalid-this
 
 import { Schema } from 'yup';
+import * as g from 'window-or-global';
 import 'reflect-metadata';
-
-const g: any = global;
 
 export const validateMetadataKey = g.ConvectorValidateMetadataKey || Symbol('validate');
 g.ConvectorValidateMetadataKey = validateMetadataKey;

--- a/@worldsibu/convector-core-storage/package.json
+++ b/@worldsibu/convector-core-storage/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "@worldsibu/convector-core-errors": "^1.3.4",
-    "tslib": "^1.9.0"
+    "tslib": "^1.9.0",
+    "window-or-global": "^1.0.1"
   },
   "devDependencies": {
     "http-server": "^0.11.1",

--- a/@worldsibu/convector-core-storage/src/base-storage.ts
+++ b/@worldsibu/convector-core-storage/src/base-storage.ts
@@ -1,6 +1,6 @@
 /** @module @worldsibu/convector-core-storage */
 
-const g: any = global;
+import * as g from 'window-or-global';
 
 export abstract class BaseStorage {
   /**


### PR DESCRIPTION
## Proposed changes

The `@worldsibu/convector-core-*` packages should be able to run on browser environments, and the global variable is breaking this.

## Types of changes

What types of changes does your code introduce to Convector?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)