### PR TITLE
feat: raw tx result with $raw()

### DIFF
--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
@@ -31,6 +31,9 @@ export class InChaincodeAdapter implements ControllerAdapter {
     // On unit tests it might change the context for the subsecuent calls
     storage.stubHelper = config.tx.stub;
 
-    return JSON.parse(res.payload.toString('utf8'));
+    return {
+      ...res,
+      result: JSON.parse(res.payload.toString('utf8'))
+    };
   }
 }

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/test/first-cc.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/test/first-cc.ts
@@ -47,7 +47,7 @@ export class FirstController extends ConvectorController {
   ): Promise<FlatConvectorModel<Third>> {
     // Cross invoke the chaincode and return what it returns
     // Do this when you DON'T have the chaincode sourcecode, all you need is the name of the fn
-    const third = await adapter.rawInvoke('third_get', { tx: this.tx, channel, chaincode }, '1');
+    const {result: third} = await adapter.rawInvoke('third_get', { tx: this.tx, channel, chaincode }, '1');
 
     // Save the external model in this ledger
     await new Third({id: `third:${id}`, ...third}).save();

--- a/@worldsibu/convector-adapter-fabric/src/fabric.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric/src/fabric.controller-adapter.ts
@@ -16,8 +16,7 @@ export class FabricControllerAdapter extends ClientHelper implements ControllerA
 
   public async invoke(controller: string, name: string, config?: any, ...args: any[]): Promise<any> {
     try {
-      const txResult = await super.invoke(`${controller}_${name}`, this.config.chaincode, config, ...args);
-      return txResult.result;
+      return await super.invoke(`${controller}_${name}`, this.config.chaincode, config, ...args);
     } catch (err) {
       if (!err.responses) {
         throw err;
@@ -43,7 +42,6 @@ export class FabricControllerAdapter extends ClientHelper implements ControllerA
   }
 
   public async query(controller: string, name: string, config?: any, ...args: any[]): Promise<any> {
-    const txResult = await super.query(`${controller}_${name}`, this.config.chaincode, config, ...args);
-    return txResult.result;
+    return super.query(`${controller}_${name}`, this.config.chaincode, config, ...args);
   }
 }

--- a/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
@@ -56,6 +56,9 @@ export class MockControllerAdapter implements ControllerAdapter {
       }]);
     }
 
-    return Transform.bufferToObject(response.payload);
+    return {
+      ...response,
+      result: Transform.bufferToObject(response.payload),
+    };
   }
 }

--- a/@worldsibu/convector-core-adapter/src/controller-client.ts
+++ b/@worldsibu/convector-core-adapter/src/controller-client.ts
@@ -8,6 +8,7 @@ export interface IConvectorControllerClient<T extends ConvectorController> {
   user: string|true;
   ctrl: new (content?: any) => T;
   adapter: ControllerAdapter;
+  raw: boolean;
 }
 
 export const controllerClientMethods = {
@@ -25,6 +26,11 @@ export const controllerClientMethods = {
     const newClient = ClientFactory(this.ctrl, this.adapter);
     newClient.config = config;
     return newClient;
+  },
+  $raw<T extends ConvectorController>(this: IConvectorControllerClient<T>) {
+    const newClient = ClientFactory(this.ctrl, this.adapter);
+    newClient.raw = true;
+    return newClient;
   }
 };
 
@@ -36,19 +42,24 @@ export function ClientFactory<T extends ConvectorController>(
   adapter: ControllerAdapter
 ): ConvectorControllerClient<T> {
   const client: ConvectorControllerClient<T> = new ctrl() as any;
-  Object.assign(client, { ctrl, adapter, query: false }, controllerClientMethods);
+  Object.assign(client, { ctrl, adapter, query: false, raw: false }, controllerClientMethods);
 
   const { namespace, invokables } = getInvokables(ctrl);
 
   for (let fn in invokables) {
-    client[fn] = function ControllerClientWrapper(this: IConvectorControllerClient<T>, ...args) {
+    client[fn] = async function ControllerClientWrapper(this: IConvectorControllerClient<T>, ...args) {
       const config = { ...this.config, user: this.user };
+      let res: any;
 
       if (this.query && adapter.query) {
-        return adapter.query(namespace, fn, config, ...args);
+        res = await adapter.query(namespace, fn, config, ...args);
       }
 
-      return adapter.invoke(namespace, fn, config, ...args);
+      res = await adapter.invoke(namespace, fn, config, ...args);
+
+      // Use the property `result` unless it's not available
+      return typeof res === 'object' && 'result' in res && !this.raw ?
+        res.result : res;
     };
   }
 

--- a/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
+++ b/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
@@ -29,15 +29,19 @@ class TestAdapter implements ControllerAdapter {
   }
 
   async invoke(controller, name, config, ...args) {
-    if (config.test) {
+    if (config.casa) {
       return 'from-adapter';
     }
 
-    return this.ctrl[name]({}, args, {});
+    return {
+      result: this.ctrl[name]({}, args, {})
+    };
   }
 
   async query(controller, name, config, ...args) {
-    return this.ctrl[name]({}, args, {});
+    return {
+      result: this.ctrl[name]({}, args, {})
+    };
   }
 }
 
@@ -60,6 +64,14 @@ describe('Controller Client', () => {
     const adapter = new TestAdapter(TestController);
     const testCtrl = ClientFactory(TestController, adapter);
 
-    expect(await testCtrl.$config({ test: true }).test()).to.eq('from-adapter');
+    expect(await testCtrl.$config({ casa: true }).test()).to.eq('from-adapter');
+  });
+
+  it('it should make a raw call, retuning all the response data', async () => {
+    const adapter = new TestAdapter(TestController);
+    const testCtrl = ClientFactory(TestController, adapter);
+
+    const response: any = await testCtrl.$raw().test();
+    expect(response).to.haveOwnProperty('result');
   });
 });

--- a/examples/token/tests/token.e2e.ts
+++ b/examples/token/tests/token.e2e.ts
@@ -102,4 +102,12 @@ describe('Token e2e', () => {
 
     expect(info).to.exist;
   });
+
+  it('should return the raw response', async () => {
+    const response: any = await tokenCtrl.$raw().getIdentityInfo();
+
+    console.log(response);
+
+    expect(response.txId).to.exist;
+  });
 });


### PR DESCRIPTION
## Proposed changes

Some times it's needed to get the whole result when sending a transaction and not just the function result. Using the client `ctrlClient.$raw()` method we can now extract the txId as well as the status.

## Types of changes

What types of changes does your code introduce to Convector?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The same way we do queries or pass custom configuration to adapters, we can now prepend an invocation with `.$raw()` to make sure we get the whole response back and not just the function invoke response. The adapters now return the whole response always and the client picks the `result` property from it, unless `$raw()` is used.