### PR TITLE
Optional params and internal invokable calls

### DIFF
--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
@@ -25,10 +25,11 @@ export class InChaincodeAdapter implements ControllerAdapter {
 
     const stub = config.tx.stub.getStub();
     // Patch mock stub
-    let beforeTx = 'signedProposal' in stub ? {
+    let beforeTx = stub.constructor.name === 'ChaincodeMockStub' ? {
       signedProposal: (stub as any).signedProposal,
       txID: (stub as any).txID,
-      transientMap: (stub as any).transientMap
+      transientMap: (stub as any).transientMap,
+      args: (stub as any).args
     } : {};
     const res = await stub.invokeChaincode(config.chaincode, [fn, ...args], config.channel);
     const storage = BaseStorage.current as StubStorage;

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
@@ -38,6 +38,11 @@ export class InChaincodeAdapter implements ControllerAdapter {
     storage.stubHelper = config.tx.stub;
     Object.assign(stub, beforeTx);
 
+    if (res.status === 500) {
+      const rawMessage = res.message.toString();
+      throw rawMessage ? JSON.parse(rawMessage) : res;
+    }
+
     const rawResult = res.payload.toString('utf8');
 
     return {

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
@@ -24,12 +24,19 @@ export class InChaincodeAdapter implements ControllerAdapter {
     }
 
     const stub = config.tx.stub.getStub();
+    // Patch mock stub
+    let beforeTx = 'signedProposal' in stub ? {
+      signedProposal: (stub as any).signedProposal,
+      txID: (stub as any).txID,
+      transientMap: (stub as any).transientMap
+    } : {};
     const res = await stub.invokeChaincode(config.chaincode, [fn, ...args], config.channel);
     const storage = BaseStorage.current as StubStorage;
 
     // Make sure the stub is still the same
     // On unit tests it might change the context for the subsecuent calls
     storage.stubHelper = config.tx.stub;
+    Object.assign(stub, beforeTx);
 
     return {
       ...res,

--- a/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-fabric-in-chaincode/src/fabric-in-chaincode.controller-adapter.ts
@@ -38,9 +38,11 @@ export class InChaincodeAdapter implements ControllerAdapter {
     storage.stubHelper = config.tx.stub;
     Object.assign(stub, beforeTx);
 
+    const rawResult = res.payload.toString('utf8');
+
     return {
       ...res,
-      result: JSON.parse(res.payload.toString('utf8'))
+      result: rawResult ? JSON.parse(rawResult) : undefined
     };
   }
 }

--- a/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
+++ b/@worldsibu/convector-adapter-mock/src/mock.controller-adapter.ts
@@ -48,7 +48,7 @@ export class MockControllerAdapter implements ControllerAdapter {
 
     const response = await this.stub.mockInvoke(uuid(), [
       `${controller}_${name}`,
-      ...args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg.toString())
+      ...args.map(arg => typeof arg === 'object' ? JSON.stringify(arg) : arg === undefined ? undefined : arg.toString())
     ], transientMap);
 
     if (response.status === 500) {

--- a/@worldsibu/convector-common-fabric-helper/src/client.helper.ts
+++ b/@worldsibu/convector-common-fabric-helper/src/client.helper.ts
@@ -334,11 +334,7 @@ export class ClientHelper {
     const txId = this.client.newTransactionID(useAdmin);
 
     request.args = (request.args || []).map(arg => {
-      if (!arg) {
-        // tslint:disable-next-line:max-line-length
-        throw new Error('Undefined parameters received as part of the transaction, check how the function is being called');
-      }
-      return typeof arg === 'object' ? JSON.stringify(arg) : arg.toString();
+      return typeof arg === 'object' ? JSON.stringify(arg) : arg !== undefined ? arg.toString() : undefined;
     });
 
     const [proposalResponses, proposal] =

--- a/@worldsibu/convector-common-fabric-helper/src/client.helper.ts
+++ b/@worldsibu/convector-common-fabric-helper/src/client.helper.ts
@@ -467,7 +467,7 @@ export class ClientHelper {
     return join(folderPath, content[0]);
   }
 
-  private renderVariables(data: string = '') {
+  private renderVariables(data = '') {
     return data.replace(/(\$[a-z_0-9]+)/ig, variable => process.env[variable.slice(1)] || variable);
   }
 }

--- a/@worldsibu/convector-core-controller/src/index.ts
+++ b/@worldsibu/convector-core-controller/src/index.ts
@@ -8,5 +8,6 @@
 
 export * from './param.decorator';
 export * from './invokable.decorator';
+export * from './optional.decorator';
 export * from './controller.decorator';
 export * from './convector-controller';

--- a/@worldsibu/convector-core-controller/src/invokable.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/invokable.decorator.ts
@@ -115,7 +115,9 @@ export function Invokable() {
       const ctx = Object.create(internalCall ? this : this[namespace], {...(extras || {}), _internal_invokable: {value:true}});
 
       try {
-        return await fn.call(ctx, ...args);
+        const response = await fn.call(ctx, ...args);
+        // Flatten the objects structure
+        return typeof response === 'object' ? JSON.parse(JSON.stringify(response)) : response;
       } catch (e) {
         const error = new Error(e.message);
         error.stack = e.stack;

--- a/@worldsibu/convector-core-controller/src/invokable.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/invokable.decorator.ts
@@ -74,7 +74,7 @@ export function Invokable() {
       if (schemas) {
         const optionals: number[] = Reflect.getOwnMetadata(optionalMetadataKey, target, key) || [];
 
-        if (schemas.length - optionals.length < args.length) {
+        if (schemas.length - optionals.length > args.length) {
           throw new ControllerInvalidInvokeError(key, args.length, schemas.length - optionals.length);
         }
 

--- a/@worldsibu/convector-core-controller/src/invokable.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/invokable.decorator.ts
@@ -112,7 +112,10 @@ export function Invokable() {
       }
 
       const namespace = Reflect.getMetadata(controllerMetadataKey, target.constructor);
-      const ctx = Object.create(internalCall ? this : this[namespace], {...(extras || {}), _internal_invokable: {value:true}});
+      const ctx = Object.create(internalCall ? this : this[namespace], {
+        ...(extras || {}),
+        _internal_invokable: {value:true}
+      });
 
       try {
         const response = await fn.call(ctx, ...args);

--- a/@worldsibu/convector-core-controller/src/optional.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/optional.decorator.ts
@@ -1,0 +1,28 @@
+/** @module convector-core-controller */
+
+import * as g from 'window-or-global';
+import { Schema, object } from 'yup';
+import 'reflect-metadata';
+
+/** @hidden */
+const isSchema = (schema: any): schema is Schema<any> => 'validate' in schema;
+
+/** @hidden */
+export const optionalMetadataKey = g.ConvectorOptionalParamMetadataKey || Symbol('optional-param');
+g.ConvectorOptionalParamMetadataKey = optionalMetadataKey;
+
+/**
+ * Used to flag the parameters as optional
+ *
+ * @decorator
+ */
+export function Optional<T>() {
+  return (target: any, propertyKey: string, parameterIndex: number) => {
+
+    const optionals: number[] =
+      Reflect.getOwnMetadata(optionalMetadataKey, target, propertyKey) || [];
+
+    optionals.push(parameterIndex);
+    Reflect.defineMetadata(optionalMetadataKey, optionals, target, propertyKey);
+  };
+}

--- a/@worldsibu/convector-core-controller/src/optional.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/optional.decorator.ts
@@ -16,7 +16,7 @@ g.ConvectorOptionalParamMetadataKey = optionalMetadataKey;
  *
  * @decorator
  */
-export function Optional<T>() {
+export function OptionalParam<T>() {
   return (target: any, propertyKey: string, parameterIndex: number) => {
 
     const optionals: number[] =

--- a/@worldsibu/convector-core-controller/src/optional.decorator.ts
+++ b/@worldsibu/convector-core-controller/src/optional.decorator.ts
@@ -1,11 +1,7 @@
 /** @module convector-core-controller */
 
 import * as g from 'window-or-global';
-import { Schema, object } from 'yup';
 import 'reflect-metadata';
-
-/** @hidden */
-const isSchema = (schema: any): schema is Schema<any> => 'validate' in schema;
 
 /** @hidden */
 export const optionalMetadataKey = g.ConvectorOptionalParamMetadataKey || Symbol('optional-param');

--- a/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
+++ b/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
@@ -62,6 +62,14 @@ class Test extends ConvectorController {
   ) {
     return model;
   }
+
+  @Invokable()
+  public async internalCall(
+    @Param(yup.string())
+    name: string
+  ) {
+    return this.plain(name);
+  }
 }
 
 describe('Invokable Decorator', () => {
@@ -108,6 +116,12 @@ describe('Invokable Decorator', () => {
 
   it('should translate a chaincode call into a controller call', async () => {
     const result = await test.plain
+      .call(testCC, new StubHelper(stub), ['test'], getExtras());
+    expect(result).to.eq('test');
+  });
+
+  it('should allow internal calls to be made in the methods', async () => {
+    const result = await test.internalCall
       .call(testCC, new StubHelper(stub), ['test'], getExtras());
     expect(result).to.eq('test');
   });

--- a/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
+++ b/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
@@ -8,7 +8,7 @@ import { Chaincode, StubHelper } from '@theledger/fabric-chaincode-utils';
 import 'mocha';
 import 'reflect-metadata';
 
-import { Validate } from '@worldsibu/convector-core-model';
+import { Validate, ConvectorModel } from '@worldsibu/convector-core-model';
 
 import { Param } from '../src/param.decorator';
 import { Controller } from '../src/controller.decorator';
@@ -24,13 +24,11 @@ class TestCC extends Chaincode {
   }
 }
 
-class TestModel {
+class TestModel extends ConvectorModel<TestModel> {
+  public type = 'test';
+
   @Validate(yup.string())
   public name: string;
-
-  constructor(content) {
-    this.name = content.name;
-  }
 }
 
 @Controller('test')
@@ -142,15 +140,14 @@ describe('Invokable Decorator', () => {
     const result = await test.complex
       .call(testCC, new StubHelper(stub), [JSON.stringify({ name: 'test' })], getExtras());
 
-    expect(result).to.be.instanceof(TestModel);
-    expect(result.name).to.eq('test');
+    expect(new TestModel(result).name).to.eq('test');
   });
 
   it('should succeed accepting an incomplete model as a param if it is for update the content', async () => {
     const result = await test.update
       .call(testCC, new StubHelper(stub), [JSON.stringify({})], getExtras());
 
-    expect(result).to.be.instanceof(TestModel);
+    expect(new TestModel(result)).to.be.instanceof(TestModel);
   });
 
   it('should allow invokes with optional params', async () => {

--- a/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
+++ b/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
@@ -14,6 +14,7 @@ import { Param } from '../src/param.decorator';
 import { Controller } from '../src/controller.decorator';
 import { ConvectorController } from '../src/convector-controller';
 import { Invokable, getInvokables } from '../src/invokable.decorator';
+import { Optional } from '../src/optional.decorator';
 
 class TestCC extends Chaincode {
   constructor(ctr: any) {
@@ -69,6 +70,17 @@ class Test extends ConvectorController {
     name: string
   ) {
     return this.plain(name);
+  }
+
+  @Invokable()
+  public async optionalParam(
+    @Param(yup.string())
+    name: string,
+    @Optional()
+    @Param(yup.string())
+    sufix: string = 'test'
+  ) {
+    return `${name} ${sufix}`;
   }
 }
 
@@ -139,5 +151,16 @@ describe('Invokable Decorator', () => {
       .call(testCC, new StubHelper(stub), [JSON.stringify({})], getExtras());
 
     expect(result).to.be.instanceof(TestModel);
+  });
+
+  it('should allow invokes with optional params', async () => {
+    const result = await test.optionalParam
+      .call(testCC, new StubHelper(stub), ['test'], getExtras());
+    expect(result).to.eq('test test');
+  });
+
+  it('should reject if less parameters are passed', async () => {
+    await test.optionalParam.call(testCC, new StubHelper(stub), [], getExtras())
+      .then(() => expect.fail('It should have failed'), () => console.log('Expected error'));
   });
 });

--- a/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
+++ b/@worldsibu/convector-core-controller/tests/invokable.decorator.spec.ts
@@ -14,7 +14,7 @@ import { Param } from '../src/param.decorator';
 import { Controller } from '../src/controller.decorator';
 import { ConvectorController } from '../src/convector-controller';
 import { Invokable, getInvokables } from '../src/invokable.decorator';
-import { Optional } from '../src/optional.decorator';
+import { OptionalParam } from '../src/optional.decorator';
 
 class TestCC extends Chaincode {
   constructor(ctr: any) {
@@ -76,7 +76,7 @@ class Test extends ConvectorController {
   public async optionalParam(
     @Param(yup.string())
     name: string,
-    @Optional()
+    @OptionalParam()
     @Param(yup.string())
     sufix: string = 'test'
   ) {

--- a/@worldsibu/convector-core-controller/tests/optional.decorator.spec.ts
+++ b/@worldsibu/convector-core-controller/tests/optional.decorator.spec.ts
@@ -6,9 +6,9 @@ import 'mocha';
 import 'reflect-metadata';
 
 import { Param, paramMetadataKey } from '../src/param.decorator';
-import { Optional, optionalMetadataKey } from '../src/optional.decorator';
+import { OptionalParam, optionalMetadataKey } from '../src/optional.decorator';
 
-describe('Optional Decorator', () => {
+describe('OptionalParam Decorator', () => {
   class TestModel {
     public name: string;
 
@@ -21,7 +21,7 @@ describe('Optional Decorator', () => {
     test(
       @Param(yup.number())
       param1: number,
-      @Optional()
+      @OptionalParam()
       @Param(TestModel)
       param2: TestModel
     ) {

--- a/@worldsibu/convector-core-controller/tests/optional.decorator.spec.ts
+++ b/@worldsibu/convector-core-controller/tests/optional.decorator.spec.ts
@@ -1,0 +1,44 @@
+// tslint:disable:no-unused-expression
+
+import * as yup from 'yup';
+import { expect } from 'chai';
+import 'mocha';
+import 'reflect-metadata';
+
+import { Param, paramMetadataKey } from '../src/param.decorator';
+import { Optional, optionalMetadataKey } from '../src/optional.decorator';
+
+describe('Optional Decorator', () => {
+  class TestModel {
+    public name: string;
+
+    constructor(content) {
+      this.name = content.name;
+    }
+  }
+
+  class TestController {
+    test(
+      @Param(yup.number())
+      param1: number,
+      @Optional()
+      @Param(TestModel)
+      param2: TestModel
+    ) {
+      // empty block
+    }
+  }
+
+  it('should register all the parameters', () => {
+    const schemas = Reflect.getMetadata(paramMetadataKey, new TestController(), 'test');
+
+    expect(schemas.length).to.eq(2);
+  });
+
+  it('should recognize the optional params', () => {
+    const optionals = Reflect.getMetadata(optionalMetadataKey, new TestController(), 'test');
+
+    // TestModel schema
+    expect(optionals[0]).to.eq(1);
+  });
+});

--- a/@worldsibu/convector-core-errors/src/controller.errors.ts
+++ b/@worldsibu/convector-core-errors/src/controller.errors.ts
@@ -96,6 +96,19 @@ export class ControllerInvalidInvokeError extends BaseError {
   }
 }
 
+export class ControllerUndefinedArgumentError extends BaseError {
+  public code = 'CTRL_UNDEF_ARG_ERR';
+  public description = 'Undefined argument passed in controller';
+  public explanation = `
+    Undefined argument #${this.index}, use @Optional() if need to omit
+    ${chaincodeSideMessage}`;
+
+  constructor(public index: number) {
+    super();
+    this.message = super.getMessage(super.getOriginal());
+  }
+}
+
 export class ControllerInvalidArgumentError extends BaseError {
   public code = 'CTRL_INV_ARG_ERR';
   public description = 'Invalid argument passed in controller';

--- a/@worldsibu/convector-platform-fabric/package.json
+++ b/@worldsibu/convector-platform-fabric/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@worldsibu/convector-adapter-fabric": "^1.3.8",
+    "@worldsibu/convector-adapter-fabric-in-chaincode": "^1.3.8",
     "@worldsibu/convector-common-fabric-helper": "^1.3.8",
     "@worldsibu/convector-core-chaincode": "^1.3.8",
     "@worldsibu/convector-storage-stub": "^1.3.8",

--- a/@worldsibu/convector-platform-fabric/src/index.ts
+++ b/@worldsibu/convector-platform-fabric/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@worldsibu/convector-adapter-fabric';
+export * from '@worldsibu/convector-adapter-fabric-in-chaincode';
 export * from '@worldsibu/convector-core-chaincode';
 export * from '@worldsibu/convector-common-fabric-helper';
 export * from '@worldsibu/convector-storage-stub';


### PR DESCRIPTION
## Proposed changes

Call a invokable function was not possible due to the params manipulation of the decorator. This PR fixes the problem for internal function invocation by keeping track of the parameters in the right position. Also, while performing these changes, the lack of an OptionalParam decorator was evident, thus it was included to cover those scenarios.

## Types of changes

What types of changes does your code introduce to Convector?

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

When you have an optional param in your invokable method, simply decorate it with `@OptionalParam()` in order to convector be aware of it and process it accordingly.

```ts
  @Invokable()
  public async optionalParam(
    @Param(yup.string())
    name: string,
    @OptionalParam()
    @Param(yup.string())
    sufix: string = 'test'
  )
```
