### PR TITLE
fix: allow multiple controller client methods use

### DIFF
--- a/@worldsibu/convector-core-adapter/src/controller-client.ts
+++ b/@worldsibu/convector-core-adapter/src/controller-client.ts
@@ -13,22 +13,22 @@ export interface IConvectorControllerClient<T extends ConvectorController> {
 
 export const controllerClientMethods = {
   $withUser<T extends ConvectorController>(this: IConvectorControllerClient<T>, user: string|true) {
-    const newClient = ClientFactory(this.ctrl, this.adapter);
+    const newClient = ClientFactory(this.ctrl, this.adapter, this);
     newClient.user = user;
     return newClient;
   },
   $query<T extends ConvectorController>(this: IConvectorControllerClient<T>) {
-    const newClient = ClientFactory(this.ctrl, this.adapter);
+    const newClient = ClientFactory(this.ctrl, this.adapter, this);
     newClient.query = true;
     return newClient;
   },
   $config<T extends ConvectorController>(this: IConvectorControllerClient<T>, config: any) {
-    const newClient = ClientFactory(this.ctrl, this.adapter);
+    const newClient = ClientFactory(this.ctrl, this.adapter, this);
     newClient.config = config;
     return newClient;
   },
   $raw<T extends ConvectorController>(this: IConvectorControllerClient<T>) {
-    const newClient = ClientFactory(this.ctrl, this.adapter);
+    const newClient = ClientFactory(this.ctrl, this.adapter, this);
     newClient.raw = true;
     return newClient;
   }
@@ -39,10 +39,11 @@ export type ConvectorControllerClient<T extends ConvectorController> =
 
 export function ClientFactory<T extends ConvectorController>(
   ctrl: new (content?: any) => T,
-  adapter: ControllerAdapter
+  adapter: ControllerAdapter,
+  extrasProperties?: IConvectorControllerClient<T>
 ): ConvectorControllerClient<T> {
   const client: ConvectorControllerClient<T> = new ctrl() as any;
-  Object.assign(client, { ctrl, adapter, query: false, raw: false }, controllerClientMethods);
+  Object.assign(client, { ctrl, adapter, query: false, raw: false }, controllerClientMethods, extrasProperties || {});
 
   const { namespace, invokables } = getInvokables(ctrl);
 

--- a/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
+++ b/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
@@ -74,4 +74,15 @@ describe('Controller Client', () => {
     const response: any = await testCtrl.$raw().test();
     expect(response).to.haveOwnProperty('result');
   });
+
+  it.only('it should pass config to adapter and query the controllers', async () => {
+    const adapter = new TestAdapter(TestController);
+    const testCtrl = ClientFactory(TestController, adapter);
+    const mockData = {car: 'Range Rover Vogue', color: "Silicon Silver"}
+
+    const newCtrl = testCtrl.$config(mockData).$query();
+
+    expect(newCtrl.config, 'config params passed correctly').to.eq(mockData);
+    expect(newCtrl.query, 'query property passed correctly').to.true;
+  });
 });

--- a/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
+++ b/@worldsibu/convector-core-adapter/tests/controller-client.spec.ts
@@ -75,7 +75,7 @@ describe('Controller Client', () => {
     expect(response).to.haveOwnProperty('result');
   });
 
-  it.only('it should pass config to adapter and query the controllers', async () => {
+  it('it should pass config to adapter and query the controllers', async () => {
     const adapter = new TestAdapter(TestController);
     const testCtrl = ClientFactory(TestController, adapter);
     const mockData = {car: 'Range Rover Vogue', color: "Silicon Silver"}


### PR DESCRIPTION
Signed-off-by: JonathanDe <jonathand9295@gmail.com>

## Proposed changes

When we are using the $... methods from our controllers in a row it happens that the last method used overwrites what the previous method did, this fix allows us to use multiple $... methods if we want to use multiple of them at the same time

## Types of changes

What types of changes does your code introduce to Convector?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/hyperledger-labs/convector/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] All the commits have been squashed into a single commit following the [conventional commits guide](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [X] All the commits are signed with [git sign-off](https://git-scm.com/docs/git-commit#git-commit--s)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
